### PR TITLE
Explicitly decode files as utf-8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ install_requires = []
 if sys.version_info[0] == 2:
     install_requires = ["enum34", "typing"]
 
-with open("README.md") as f:
-    readme = f.read()
+with open("README.md", "rb") as f:
+    readme = f.read().decode("utf-8")
 
 about = {}
-with open("openlr/_version.py") as f:
-    exec(f.read(), about)
+with open("openlr/_version.py", "rb") as f:
+    exec(f.read().decode("utf-8"), about)
 
 setup(
     name=about["__title__"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "rb") as f:
 
 about = {}
 with open("openlr/_version.py", "rb") as f:
-    exec(f.read().decode("utf-8"), about)
+    exec(f.read(), about)
 
 setup(
     name=about["__title__"],

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ install_requires = []
 if sys.version_info[0] == 2:
     install_requires = ["enum34", "typing"]
 
-with open("README.md", encoding="utf-8") as f:
-    readme = f.read()
+with open("README.md", "rb") as f:
+    readme = f.read().decode("utf-8")
 
 about = {}
 with open("openlr/_version.py", "rb") as f:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ install_requires = []
 if sys.version_info[0] == 2:
     install_requires = ["enum34", "typing"]
 
-with open("README.md", "rb") as f:
-    readme = f.read().decode("utf-8")
+with open("README.md", encoding="utf-8") as f:
+    readme = f.read()
 
 about = {}
 with open("openlr/_version.py", "rb") as f:


### PR DESCRIPTION
Both README and _version.py seem to contain non-ascii characters, and this code fails when ascii encoding is used.

Tested with:
```
LANG=ascii python3 setup.py egg_info
```